### PR TITLE
Feat/dnd layout

### DIFF
--- a/src/components/Board/Card.js
+++ b/src/components/Board/Card.js
@@ -21,9 +21,10 @@ const useStyles = makeStyles({
   root: {
     borderRadius: "5px",
     minWidth: 275,
-    background: `linear-gradient(45deg, #10459f 30%, #3C78DF 90%)`,
+    background: "linear-gradient(45deg, #10459f 30%, #3C78DF 90%)",
+
     //none|h-offset v-offset blur spread color |inset|initial|inherit;
-    boxShadow: "-20px 50px 80px -30px black",
+    boxShadow: "-20px 80px 80px -30px black",
     // background: `url(${BluePaper}) repeat`,
     display: "block",
     width: "420px",

--- a/src/components/Board/Card.js
+++ b/src/components/Board/Card.js
@@ -18,7 +18,8 @@ const useStyles = makeStyles({
     minWidth: 275,
     background: `linear-gradient(45deg, #10459f 30%, #3C78DF 90%)`,
     //none|h-offset v-offset blur spread color |inset|initial|inherit;
-    boxShadow: "-40px 50px 80px -30px black",
+
+    boxShadow: "-20px 50px 80px -30px black",
     // background: `url(${BluePaper}) repeat`,
     display: "block",
     width: "420px",
@@ -106,7 +107,7 @@ const useStyles = makeStyles({
   },
 });
 
-export default function AHCard() {
+export default function AHCard(props) {
   const [description, setDescription] = useState("");
   const classes = useStyles();
   const CHARACTER_LIMIT = 20;
@@ -115,9 +116,12 @@ export default function AHCard() {
     <Card className={classes.root} display="inline">
       <CardContent>
         <Typography className={classes.title} gutterBottom>
-          <span>
-            <img className={classes.ahlogo} src={ahLogoWit} alt="" />
-          </span>
+          {/* <span
+            {...props.provided.dragHandleProps}
+            ref={props.provided.innerRef}
+          > */}
+          <img className={classes.ahlogo} src={ahLogoWit} alt="" />
+          {/* </span> */}
           Aangeboden
           <Checkbox color="default" className={classes.checkbox} />
           Gevraagd

--- a/src/components/Board/Card.js
+++ b/src/components/Board/Card.js
@@ -11,6 +11,10 @@ import Typography from "@material-ui/core/Typography";
 // import BluePaper from "../img/old-blue-paper.jpg";
 import ahLogoWit from "../img/ahlogo4.png";
 
+import { setLayoutState } from "../../store/editor/actions";
+import { useDispatch, useSelector } from "react-redux";
+import { selectLayoutState } from "../../store/editor/selectors";
+
 import Checkbox from "@material-ui/core/Checkbox";
 
 const useStyles = makeStyles({
@@ -132,8 +136,25 @@ const useStyles = makeStyles({
 
 export default function AHCard(props) {
   const [description, setDescription] = useState("");
+  const dispatch = useDispatch();
+  const layoutState = useSelector(selectLayoutState);
   const classes = useStyles();
   const CHARACTER_LIMIT = 20;
+
+  const onFieldChangeHandler = (e) => {
+    const newState = {
+      ...layoutState,
+      ptexts: {
+        ...layoutState.ptexts,
+        [props?.ptextId]: {
+          ...layoutState.ptexts[props?.ptextId],
+          [e.target.name]: e.target.value,
+        },
+      },
+    };
+    // console.log("newState", newState);
+    dispatch(setLayoutState(newState));
+  };
 
   return (
     <Card className={classes.root} display="inline">
@@ -146,11 +167,23 @@ export default function AHCard(props) {
           <img className={classes.ahlogo} src={ahLogoWit} alt="" />
           {/* </span> */}
           Aangeboden
-          <Checkbox color="default" className={classes.checkbox} />
+          <Checkbox
+            name="aangeboden"
+            onChange={onFieldChangeHandler}
+            color="default"
+            className={classes.checkbox}
+          />
           Gevraagd
-          <Checkbox color="default" className={classes.checkbox} />
+          <Checkbox
+            name="gevraagd"
+            onChange={onFieldChangeHandler}
+            color="default"
+            className={classes.checkbox}
+          />
           <span className={classes.datumboxlabel}>Datum </span>
           <TextField
+            onChange={onFieldChangeHandler}
+            name="datum"
             margin="dense"
             rows={1}
             rowsMax={1}
@@ -167,6 +200,8 @@ export default function AHCard(props) {
           />
         </Typography>
         <TextField
+          name="title"
+          onChange={onFieldChangeHandler}
           margin="dense"
           rows={1}
           rowsMax={1}
@@ -182,8 +217,9 @@ export default function AHCard(props) {
           }}
         />
         <TextField
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          // value={layoutState?.ptexts[props?.ptextId].content}
+          name="description"
+          onChange={onFieldChangeHandler}
           rows={6}
           rowsMax={6}
           step="1"
@@ -205,6 +241,8 @@ export default function AHCard(props) {
         <Typography>
           <span className={classes.nameboxlabel}>Naam </span>
           <TextField
+            name="name"
+            onChange={onFieldChangeHandler}
             margin="dense"
             rows={1}
             rowsMax={1}
@@ -221,6 +259,8 @@ export default function AHCard(props) {
           />
           <span className={classes.phoneboxlabel}>Telefoon </span>
           <TextField
+            name="telephone"
+            onChange={onFieldChangeHandler}
             margin="dense"
             rows={1}
             rowsMax={1}
@@ -239,6 +279,8 @@ export default function AHCard(props) {
         <Typography>
           <span className={classes.nameboxlabel}>E-mail </span>
           <TextField
+            name="email"
+            onChange={onFieldChangeHandler}
             disableUnderline={true}
             margin="dense"
             rows={1}

--- a/src/components/Board/Card.js
+++ b/src/components/Board/Card.js
@@ -55,6 +55,13 @@ const useStyles = makeStyles({
     fontSize: 10,
     color: "white",
   },
+  datumboxlabel: {
+    position: "relative",
+    top: "-1px",
+    left: 5,
+    fontSize: 10,
+    color: "white",
+  },
   phoneboxlabel: {
     position: "relative",
     top: "-2px",
@@ -62,6 +69,22 @@ const useStyles = makeStyles({
     color: "white",
     marginLeft: 4,
     marginRight: 2,
+  },
+
+  datumbox: {
+    position: "relative",
+    borderRadius: "5px",
+    background: "white",
+    height: 20,
+    top: 9,
+    left: 11,
+    // marginTop: 2,
+    marginLeft: 1,
+    marginBottom: 2,
+    width: "103px",
+    input: {
+      color: "black",
+    },
   },
   namebox: {
     borderRadius: "5px",
@@ -126,6 +149,22 @@ export default function AHCard(props) {
           <Checkbox color="default" className={classes.checkbox} />
           Gevraagd
           <Checkbox color="default" className={classes.checkbox} />
+          <span className={classes.datumboxlabel}>Datum </span>
+          <TextField
+            margin="dense"
+            rows={1}
+            rowsMax={1}
+            className={classes.datumbox}
+            InputProps={{
+              style: {
+                fontSize: 10,
+                fontFamily: "Bradley Hand",
+                marginLeft: 4,
+                marginTop: 2,
+              },
+              disableUnderline: true,
+            }}
+          />
         </Typography>
         <TextField
           margin="dense"

--- a/src/components/Board/Card.js
+++ b/src/components/Board/Card.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
 
@@ -109,7 +109,7 @@ const useStyles = makeStyles({
     height: 20,
     width: "356px",
     input: {
-      disableUnderline: "true",
+      // disableUnderline: "true",
       color: "black",
     },
   },
@@ -135,7 +135,6 @@ const useStyles = makeStyles({
 });
 
 export default function AHCard(props) {
-  const [description, setDescription] = useState("");
   const dispatch = useDispatch();
   const layoutState = useSelector(selectLayoutState);
   const classes = useStyles();
@@ -159,7 +158,7 @@ export default function AHCard(props) {
   return (
     <Card className={classes.root} display="inline">
       <CardContent>
-        <Typography className={classes.title} gutterBottom>
+        <Typography className={classes.title} component={"span"} gutterBottom>
           {/* <span
             {...props.provided.dragHandleProps}
             ref={props.provided.innerRef}
@@ -230,7 +229,7 @@ export default function AHCard(props) {
             style: { fontSize: 14, fontFamily: "Bradley Hand", marginLeft: 2 },
             disableUnderline: true,
             inputProps: {
-              maxlength: CHARACTER_LIMIT,
+              maxLength: CHARACTER_LIMIT,
               className: classes.input,
             },
           }}
@@ -238,7 +237,7 @@ export default function AHCard(props) {
           multiline
           fullWidth
         />
-        <Typography>
+        <Typography component={"span"}>
           <span className={classes.nameboxlabel}>Naam </span>
           <TextField
             name="name"
@@ -276,12 +275,11 @@ export default function AHCard(props) {
             }}
           />
         </Typography>
-        <Typography>
+        <Typography component={"span"}>
           <span className={classes.nameboxlabel}>E-mail </span>
           <TextField
             name="email"
             onChange={onFieldChangeHandler}
-            disableUnderline={true}
             margin="dense"
             rows={1}
             rowsMax={1}
@@ -295,13 +293,13 @@ export default function AHCard(props) {
               },
               disableUnderline: true,
               inputProps: {
-                maxlength: CHARACTER_LIMIT,
+                maxLength: CHARACTER_LIMIT,
                 className: classes.input,
               },
             }}
           />
         </Typography>
-        <Typography>
+        <Typography component={"span"}>
           <span className={classes.footertext}>
             OM HET AANBOD ACTUEEL TE HOUDEN, WORDEN KAARTJES NA 14 DAGEN
             VERWIJDERD.

--- a/src/components/Board/Card.js
+++ b/src/components/Board/Card.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
+
 // import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import TextField from "@material-ui/core/TextField";
@@ -18,7 +19,6 @@ const useStyles = makeStyles({
     minWidth: 275,
     background: `linear-gradient(45deg, #10459f 30%, #3C78DF 90%)`,
     //none|h-offset v-offset blur spread color |inset|initial|inherit;
-
     boxShadow: "-20px 50px 80px -30px black",
     // background: `url(${BluePaper}) repeat`,
     display: "block",

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+import DndLayout from "./dndLayout";
+import styled from "styled-components";
+
+import TextField from "@material-ui/core/TextField";
+import AddIcon from "@material-ui/icons/Add";
+
+import { useDispatch, useSelector } from "react-redux";
+import { selectLayoutState } from "../../store/editor/selectors";
+import { selectContentDescription } from "../../store/editor/selectors";
+
+import { nlpRequest } from "../../store/lookup/actions";
+import { populatePtexts } from "../../store/lookup/actions";
+import { addNewColumn } from "../../store/editor/actions";
+import { setContentDescription } from "../../store/editor/actions";
+
+const EditorContainer = styled.div`
+  display: flex;
+  // flex-direction: column;
+  justify-content: center;
+`;
+const LayoutContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  // justify-content: center;
+  // background-color: lightblue;
+  width: 800px;
+`;
+const DescriptionContainer = styled.div`
+  // display: flex;
+  // justify-content: center;
+  width: 300px;
+  margin-right: 80px;
+  // background-color: royalblue;
+`;
+const AddContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+`;
+
+export default function Editor() {
+  const [editMode, setEditMode] = useState(false);
+  const layoutState = useSelector(selectLayoutState);
+  const contentDescription = useSelector(selectContentDescription);
+
+  const dispatch = useDispatch();
+
+  const onNlpRequest = () => {
+    dispatch(nlpRequest(contentDescription));
+  };
+
+  const onPopulatePtexts = () => {
+    dispatch(populatePtexts());
+  };
+
+  const onAddNewColumn = () => {
+    dispatch(addNewColumn());
+  };
+
+  // function timeOutLatch() {
+
+  //   setTimeout(() => {
+  //     console.log("delayed!");
+
+  //   }, 1000);
+  // }
+
+  const onChangeContentDescription = (e) => {
+    dispatch(setContentDescription(e.target.value));
+    setTimeout(() => {
+      console.log("delayed!");
+    }, 2000);
+    // onNlpRequest();
+  };
+
+  return (
+    <div>
+      {/* <button onClick={onAddNewColumn}> */}
+      {/* </button> */}
+      <button onClick={onNlpRequest}>req</button>
+      <button onClick={onPopulatePtexts}>pop</button>
+      <EditorContainer>
+        <DescriptionContainer>
+          <TextField
+            label="what are you thinking? ... "
+            fullWidth={true}
+            value={contentDescription}
+            onChange={onChangeContentDescription}
+            multiline
+          />
+        </DescriptionContainer>
+        <LayoutContainer>
+          <DndLayout layoutState={layoutState} />
+          <AddContainer>
+            <AddIcon onClick={onAddNewColumn} />
+          </AddContainer>
+        </LayoutContainer>
+      </EditorContainer>
+
+      {/* <AddContainer {...props}>
+        <AddIcon onClick={onAddNewColumn} />
+      </AddContainer> */}
+    </div>
+  );
+}

--- a/src/components/Editor/column.js
+++ b/src/components/Editor/column.js
@@ -4,7 +4,8 @@ import Ptext from "./ptext";
 
 import Paper from "@material-ui/core/Paper";
 
-import { Droppable, Draggable } from "react-beautiful-dnd";
+import { Droppable } from "react-beautiful-dnd";
+// import { Draggable } from "react-beautiful-dnd";
 
 //flex-direction / flex-grow / min-height   are essential
 const Container = styled.div`
@@ -18,9 +19,9 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
 `;
-const Title = styled.h3`
-  padding: 8px;
-`;
+// const Title = styled.h3`
+//   padding: 8px;
+// `;
 
 const PtextList = styled.div`
   padding: 8px;
@@ -34,38 +35,48 @@ const PtextList = styled.div`
 
 export default function Column(props) {
   return (
-    <Draggable draggableId={props.column.id} index={props.index}>
-      {(provided) => (
-        <Container {...provided.draggableProps} ref={provided.innerRef}>
-          <Paper>
-            {/* <Title {...provided.dragHandleProps}>{props.column.title}</Title> */}
-            <Droppable
-              droppableId={props.column?.id}
-              type="active"
-              //create droppable rules based on 'type' assignment
-              // type={props.column.id === "column-3" ? "done" : "active"}
-              //disable the dropping draggables on this droppable
-              isDropDisabled={props.isDropDisabled}
-              direction="horizontal"
+    /*
+    ### optional draggable droppables
+     <Draggable draggableId={props.column.id} index={props.index}>
+     {(provided) => (
+     <Container {...provided.draggableProps} ref={provided.innerRef}>
+    */
+    <Container>
+      <Paper>
+        {/* ### provide drag handle for draggable droppable */}
+        {/* <Title {...provided.dragHandleProps}>{props.column.title}</Title> */}
+
+        <Droppable
+          droppableId={props.column?.id}
+          type="active"
+          //create droppable rules based on 'type' assignment
+          //  type={props.column.id === "column-3" ? "done" : "active"}
+          //disable the dropping draggables on this droppable
+
+          isDropDisabled={props.isDropDisabled}
+          direction="horizontal"
+        >
+          {(provided, snapshot) => (
+            <PtextList
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              isDraggingOver={snapshot.isDraggingOver}
             >
-              {(provided, snapshot) => (
-                <PtextList
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                  isDraggingOver={snapshot.isDraggingOver}
-                >
-                  {props.ptexts
-                    ? props.ptexts.map((ptext, index) => (
-                        <Ptext key={ptext?.id} ptext={ptext} index={index} />
-                      ))
-                    : null}
-                  {provided.placeholder}
-                </PtextList>
-              )}
-            </Droppable>
-          </Paper>
-        </Container>
-      )}
-    </Draggable>
+              {props.ptexts
+                ? props.ptexts.map((ptext, index) => (
+                    <Ptext key={ptext?.id} ptext={ptext} index={index} />
+                  ))
+                : null}
+              {provided.placeholder}
+            </PtextList>
+          )}
+        </Droppable>
+      </Paper>
+    </Container>
+    /*
+    // ### closing for draggable droppables
+     )}
+     </Draggable>
+    */
   );
 }

--- a/src/components/Editor/column.js
+++ b/src/components/Editor/column.js
@@ -1,20 +1,35 @@
 import React from "react";
 import styled from "styled-components";
-// import Ptext from "./ptext";
-import AHCard from "../Board/Card.js";
+import Ptext from "./ptext";
+
 import Paper from "@material-ui/core/Paper";
+
 import { Droppable, Draggable } from "react-beautiful-dnd";
 
 //flex-direction / flex-grow / min-height   are essential
 const Container = styled.div`
-  margin: 40px;
+  margin: 8px;
+  /* border: 1px solid lightgrey; */
+
+  border-radius: 6px;
+  // width: 800px;
+  background-color: white;
+
+  display: flex;
+  flex-direction: column;
 `;
 const Title = styled.h3`
-  position: relative;
-  padding: 30px;
-  // background: red;
-  bottom: -80px;
-  color: transparent;
+  padding: 8px;
+`;
+
+const PtextList = styled.div`
+  padding: 8px;
+  transition: background-color 0.3s ease;
+  background-color: ${(props) => (props.isDraggingOver ? "white" : "inherit")};
+  // flex-grow: 1;
+  // min-height: 100px;
+
+  display: flex;
 `;
 
 export default function Column(props) {
@@ -22,10 +37,33 @@ export default function Column(props) {
     <Draggable draggableId={props.column.id} index={props.index}>
       {(provided) => (
         <Container {...provided.draggableProps} ref={provided.innerRef}>
-          <Title {...provided.dragHandleProps}>
-            ------------------------------------------
-          </Title>
-          <AHCard boxshadowdepth={props.isDragging} />
+          <Paper>
+            {/* <Title {...provided.dragHandleProps}>{props.column.title}</Title> */}
+            <Droppable
+              droppableId={props.column?.id}
+              type="active"
+              //create droppable rules based on 'type' assignment
+              // type={props.column.id === "column-3" ? "done" : "active"}
+              //disable the dropping draggables on this droppable
+              isDropDisabled={props.isDropDisabled}
+              direction="horizontal"
+            >
+              {(provided, snapshot) => (
+                <PtextList
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  isDraggingOver={snapshot.isDraggingOver}
+                >
+                  {props.ptexts
+                    ? props.ptexts.map((ptext, index) => (
+                        <Ptext key={ptext?.id} ptext={ptext} index={index} />
+                      ))
+                    : null}
+                  {provided.placeholder}
+                </PtextList>
+              )}
+            </Droppable>
+          </Paper>
         </Container>
       )}
     </Draggable>

--- a/src/components/Editor/column.js
+++ b/src/components/Editor/column.js
@@ -27,7 +27,7 @@ const PtextList = styled.div`
   transition: background-color 0.3s ease;
   background-color: ${(props) => (props.isDraggingOver ? "white" : "inherit")};
   // flex-grow: 1;
-  // min-height: 100px;
+  min-height: 280px;
 
   display: flex;
 `;

--- a/src/components/Editor/column.js
+++ b/src/components/Editor/column.js
@@ -1,0 +1,33 @@
+import React from "react";
+import styled from "styled-components";
+// import Ptext from "./ptext";
+import AHCard from "../Board/Card.js";
+import Paper from "@material-ui/core/Paper";
+import { Droppable, Draggable } from "react-beautiful-dnd";
+
+//flex-direction / flex-grow / min-height   are essential
+const Container = styled.div`
+  margin: 40px;
+`;
+const Title = styled.h3`
+  position: relative;
+  padding: 30px;
+  // background: red;
+  bottom: -80px;
+  color: transparent;
+`;
+
+export default function Column(props) {
+  return (
+    <Draggable draggableId={props.column.id} index={props.index}>
+      {(provided) => (
+        <Container {...provided.draggableProps} ref={provided.innerRef}>
+          <Title {...provided.dragHandleProps}>
+            ------------------------------------------
+          </Title>
+          <AHCard boxshadowdepth={props.isDragging} />
+        </Container>
+      )}
+    </Draggable>
+  );
+}

--- a/src/components/Editor/column.js
+++ b/src/components/Editor/column.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import Ptext from "./ptext";
+import Ptext from "./ptextModal";
 
 import Paper from "@material-ui/core/Paper";
 

--- a/src/components/Editor/dndLayout.js
+++ b/src/components/Editor/dndLayout.js
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import initialData from "./initial-data";
+import Column from "./column";
+import styled from "styled-components";
+
+import { DragDropContext, Droppable } from "react-beautiful-dnd";
+
+import { useDispatch, useSelector } from "react-redux";
+import { setLayoutState } from "../../store/editor/actions";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+function DndLayout(props) {
+  // const [state, setState] = useState(props.layoutState);
+  const dispatch = useDispatch();
+  // const state = props.layoutState;
+  const state = initialData;
+
+  const onDragStart = (start) => {
+    // document.body.style.color = "orange";
+    // document.body.style.transition = "background-color 0.2s ease";
+    //OPTIONAL::: creating rules for -not allowed to re-drop in old location-
+    // const homeIndex = state.columnOrder.indexOf(start.source.droppableId);
+    // setState({
+    //   ...state,
+    //   homeIndex: homeIndex,
+    // });
+    //TODO next clear this state onDragEnd
+  };
+
+  const onDragUpdate = (update) => {
+    // const { destination } = update;
+    // const opacity = destination
+    //   ? destination.index / Object.keys(state.tasks).length
+    //   : 0;
+    // document.body.style.backgroundColor = `rgba(153,141,217, ${opacity})`;
+  };
+
+  const onDragEnd = (result) => {
+    // document.body.style.color = "inherit";
+    // document.body.style.background = "white";
+
+    //OPTIONAL::: clearing the rules for -not allowed to re-drop in old location-
+    // setState({
+    //   ...state,
+    //   homeIndex: null,
+    // });
+
+    const { destination, source, draggableId, type } = result;
+
+    if (!destination) {
+      return;
+    }
+
+    if (
+      destination.droppableId === source.droppableId &&
+      destination.index === source.index
+    ) {
+      return;
+    }
+
+    //Column reordering logic
+    if (type === "column") {
+      const newColumnOrder = Array.from(state.columnOrder);
+      newColumnOrder.splice(source.index, 1);
+      newColumnOrder.splice(destination.index, 0, draggableId);
+
+      const newState = {
+        ...state,
+        columnOrder: newColumnOrder,
+      };
+      dispatch(setLayoutState(newState));
+      // setState(newState);
+      return;
+    }
+
+    if (state.columns) {
+      const start = state.columns[source.droppableId];
+      const finish = state.columns[destination.droppableId];
+
+      if (start === finish) {
+        const newPtextIds = Array.from(start.ptextIds);
+        //splice (from index - remove 1 item)
+        newPtextIds.splice(source.index, 1);
+        //splice (on index - insert - item)
+        newPtextIds.splice(destination.index, 0, draggableId);
+
+        const newColumn = {
+          ...start,
+          ptextIds: newPtextIds,
+        };
+
+        const newState = {
+          ...state,
+          columns: {
+            ...state.columns,
+            [newColumn.id]: newColumn,
+          },
+        };
+        dispatch(setLayoutState(newState));
+        // setState(newState);
+        return;
+        //e.g.  request endpoint POST "reorder occurred"
+      }
+
+      //moving from one list to another
+
+      const startPtextIds = Array.from(start.ptextIds);
+      startPtextIds.splice(source.index, 1);
+      const newStart = {
+        ...start,
+        ptextIds: startPtextIds,
+      };
+
+      const finishPtextIds = Array.from(finish.ptextIds);
+      finishPtextIds.splice(destination.index, 0, draggableId);
+      const newFinish = {
+        ...finish,
+        ptextIds: finishPtextIds,
+      };
+
+      const newState = {
+        ...state,
+        columns: {
+          ...state.columns,
+          [newStart.id]: newStart,
+          [newFinish.id]: newFinish,
+        },
+      };
+      dispatch(setLayoutState(newState));
+      // setState(newState);
+      return;
+    }
+  };
+  return (
+    <DragDropContext
+      onDragStart={onDragStart}
+      onDragUpdate={onDragUpdate}
+      onDragEnd={onDragEnd}
+    >
+      <Droppable droppableId="all-columns" direction="horizontal" type="column">
+        {(provided) => (
+          <Container {...provided.droppableProps} ref={provided.innerRef}>
+            {state.columnOrder.map((columnId, index) => {
+              const column = state.columns[columnId];
+              const ptexts = column.ptextIds.map(
+                (ptextId) => state.ptexts[ptextId]
+              );
+
+              //creating rule: only drop in next column allowed
+              // const isDropDisabled = index < state.homeIndex;
+
+              return (
+                <Column
+                  key={column.id}
+                  column={column}
+                  ptexts={ptexts}
+                  isDropDisabled={false}
+                  index={index}
+                />
+              );
+            })}
+            {provided.placeholder}
+          </Container>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}
+
+export default DndLayout;

--- a/src/components/Editor/dndLayout.js
+++ b/src/components/Editor/dndLayout.js
@@ -8,6 +8,7 @@ import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import { useDispatch, useSelector } from "react-redux";
 import { selectLayoutState } from "../../store/editor/selectors";
 import { setLayoutState } from "../../store/editor/actions";
+import { findByLabelText } from "@testing-library/react";
 
 const Container = styled.div`
   display: flex;
@@ -136,38 +137,86 @@ function DndLayout(props) {
     }
   };
   return (
-    <DragDropContext
-      onDragStart={onDragStart}
-      onDragUpdate={onDragUpdate}
-      onDragEnd={onDragEnd}
-    >
-      <Droppable droppableId="all-columns" direction="horizontal" type="column">
-        {(provided) => (
-          <Container {...provided.droppableProps} ref={provided.innerRef}>
-            {state.columnOrder.map((columnId, index) => {
-              const column = state.columns[columnId];
-              const ptexts = column.ptextIds.map(
-                (ptextId) => state.ptexts[ptextId]
-              );
+    <div style={{ backgroundColor: "#BEBEBE" }}>
+      <DragDropContext
+        onDragStart={onDragStart}
+        onDragUpdate={onDragUpdate}
+        onDragEnd={onDragEnd}
+      >
+        <Droppable
+          droppableId="all-columns"
+          direction="horizontal"
+          type="column"
+        >
+          {(provided) => (
+            <Container {...provided.droppableProps} ref={provided.innerRef}>
+              {state.columnOrder.map((columnId, index) => {
+                const column = state.columns[columnId];
+                const ptexts = column.ptextIds.map(
+                  (ptextId) => state.ptexts[ptextId]
+                );
 
-              //creating rule: only drop in next column allowed
-              // const isDropDisabled = index < state.homeIndex;
+                //creating rule: only drop in next column allowed
+                // const isDropDisabled = index < state.homeIndex;
 
-              return (
-                <Column
-                  key={column.id}
-                  column={column}
-                  ptexts={ptexts}
-                  isDropDisabled={false}
-                  index={index}
-                />
-              );
-            })}
-            {provided.placeholder}
-          </Container>
-        )}
-      </Droppable>
-    </DragDropContext>
+                return (
+                  <span
+                    id="cardBackgroundPlate"
+                    key={column.id}
+                    style={{
+                      margin: -20,
+                      marginTop: -60,
+                      border: "40px solid #00A0E2",
+                      height: "100%",
+                    }}
+                  >
+                    <Column
+                      // key={column.id}
+                      column={column}
+                      ptexts={ptexts}
+                      isDropDisabled={false}
+                      index={index}
+                    />
+                    <span
+                      id="glueStrip"
+                      style={{
+                        position: "relative",
+                        top: -38,
+                        left: -70,
+                      }}
+                    >
+                      <hr
+                        style={{
+                          border: 0,
+                          width: "150%",
+                          color: "white",
+                          background:
+                            "linear-gradient(to bottom right, #E8E8E8, white)",
+                          height: "50px",
+                        }}
+                      ></hr>
+                      <hr
+                        style={{
+                          border: 0,
+                          width: "150%",
+                          color: "grey",
+                          background:
+                            "linear-gradient(to bottom right, #DCDCDC, white)",
+                          // backgroundColor: "#d3d3d3",
+                          height: "50px",
+                          marginTop: -10,
+                        }}
+                      ></hr>
+                    </span>
+                  </span>
+                );
+              })}
+              {provided.placeholder}
+            </Container>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </div>
   );
 }
 

--- a/src/components/Editor/dndLayout.js
+++ b/src/components/Editor/dndLayout.js
@@ -1,23 +1,23 @@
 import React, { useState } from "react";
-import initialData from "./initial-data";
+// import initialData from "./initial-data";
 import Column from "./column";
 import styled from "styled-components";
 
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
 
 import { useDispatch, useSelector } from "react-redux";
+import { selectLayoutState } from "../../store/editor/selectors";
 import { setLayoutState } from "../../store/editor/actions";
 
 const Container = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
 `;
 
 function DndLayout(props) {
   // const [state, setState] = useState(props.layoutState);
   const dispatch = useDispatch();
-  // const state = props.layoutState;
-  const state = initialData;
+  const state = useSelector(selectLayoutState);
 
   const onDragStart = (start) => {
     // document.body.style.color = "orange";

--- a/src/components/Editor/dndLayout.js
+++ b/src/components/Editor/dndLayout.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 // import initialData from "./initial-data";
 import Column from "./column";
 import styled from "styled-components";

--- a/src/components/Editor/dndLayout.js
+++ b/src/components/Editor/dndLayout.js
@@ -8,7 +8,6 @@ import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import { useDispatch, useSelector } from "react-redux";
 import { selectLayoutState } from "../../store/editor/selectors";
 import { setLayoutState } from "../../store/editor/actions";
-import { findByLabelText } from "@testing-library/react";
 
 const Container = styled.div`
   display: flex;
@@ -137,7 +136,10 @@ function DndLayout(props) {
     }
   };
   return (
-    <div style={{ backgroundColor: "#BEBEBE" }}>
+    <div
+      style={{ background: "linear-gradient(45deg, #989898 30%, #BEBEBE 90%)" }}
+    >
+      {/* <div style={{ backgroundColor: "#BEBEBE" }}> */}
       <DragDropContext
         onDragStart={onDragStart}
         onDragUpdate={onDragUpdate}
@@ -164,6 +166,7 @@ function DndLayout(props) {
                     id="cardBackgroundPlate"
                     key={column.id}
                     style={{
+                      // background: "",
                       margin: -20,
                       marginTop: -60,
                       border: "40px solid #00A0E2",

--- a/src/components/Editor/initial-data.js
+++ b/src/components/Editor/initial-data.js
@@ -1,28 +1,28 @@
 const initialData = {
   ptexts: {
-    "ptext-1": { id: "ptext-1", content: " " },
-    "ptext-2": { id: "ptext-2", content: " " },
-    "ptext-3": { id: "ptext-3", content: " " },
-    "ptext-4": { id: "ptext-4", content: " " },
+    "ptext-1": { id: "ptext-1", content: "take out garbage" },
+    "ptext-2": { id: "ptext-2", content: "watch show" },
+    "ptext-3": { id: "ptext-3", content: "charge phone" },
+    "ptext-4": { id: "ptext-4", content: "cook dinner" },
   },
   columns: {
     "column-1": {
       id: "column-1",
-      title: " ",
-      ptextIds: ["ptext-1", "ptext-2", "ptext-3", "ptext-4"],
+      title: "Part 1 (title)",
+      ptextIds: ["ptext-1", "ptext-2", "ptext-3"],
     },
     "column-2": {
       id: "column-2",
-      title: " ",
+      title: "Part 2 (title)",
       ptextIds: [],
     },
     "column-3": {
       id: "column-3",
-      title: " ",
+      title: "Part 3 (title)",
       ptextIds: [],
     },
   },
-
+  //for reordering columns later on
   columnOrder: ["column-1", "column-2", "column-3"],
 };
 

--- a/src/components/Editor/initial-data.js
+++ b/src/components/Editor/initial-data.js
@@ -1,0 +1,29 @@
+const initialData = {
+  ptexts: {
+    "ptext-1": { id: "ptext-1", content: " " },
+    "ptext-2": { id: "ptext-2", content: " " },
+    "ptext-3": { id: "ptext-3", content: " " },
+    "ptext-4": { id: "ptext-4", content: " " },
+  },
+  columns: {
+    "column-1": {
+      id: "column-1",
+      title: " ",
+      ptextIds: ["ptext-1", "ptext-2", "ptext-3", "ptext-4"],
+    },
+    "column-2": {
+      id: "column-2",
+      title: " ",
+      ptextIds: [],
+    },
+    "column-3": {
+      id: "column-3",
+      title: " ",
+      ptextIds: [],
+    },
+  },
+
+  columnOrder: ["column-1", "column-2", "column-3"],
+};
+
+export default initialData;

--- a/src/components/Editor/ptext.js
+++ b/src/components/Editor/ptext.js
@@ -6,10 +6,6 @@ import DragHandle from "@material-ui/icons/DragHandle";
 
 import AHCard from "../Board/Card";
 
-import { setLayoutState } from "../../store/editor/actions";
-import { useDispatch, useSelector } from "react-redux";
-import { selectLayoutState } from "../../store/editor/selectors";
-
 const Container = styled.div`
   /* border: 1px solid lightgrey; */
   border-radius: 5px;
@@ -32,26 +28,9 @@ const Handle = styled.div`
 `;
 
 export default function Ptext(props) {
-  const dispatch = useDispatch();
-  const layoutState = useSelector(selectLayoutState);
-
   // OPTIONAL ::: set draggable to disabled
   const isDragDisabled = false;
   // const isDragDisabled = props.task.id === "task-1";
-
-  const onTextChangeHandler = (e) => {
-    const newState = {
-      ...layoutState,
-      ptexts: {
-        ...layoutState.ptexts,
-        [props.ptext?.id]: {
-          ...layoutState.ptexts[props.ptext?.id],
-          content: e.target.value,
-        },
-      },
-    };
-    dispatch(setLayoutState(newState));
-  };
 
   return (
     <Draggable
@@ -66,22 +45,11 @@ export default function Ptext(props) {
           ref={provided.innerRef}
           isDragging={snapshot.isDragging}
         >
-          <div>
-            <AHCard ptextId={props.ptext?.id} />
-          </div>
+          <AHCard ptextId={props.ptext?.id} />
+
           <Handle isDragDisabled={isDragDisabled} {...provided.dragHandleProps}>
             <DragHandle />
           </Handle>
-          {/* {props.ptext?.content} */}
-          {/* <TextField
-            id="standard-multiline-flexible"
-            label=""
-            multiline
-            fullWidth={true}
-            // rowsMax={4}
-            // value={layoutState.ptexts[props.ptext?.id].content}
-            onChange={onTextChangeHandler}
-          /> */}
         </Container>
       )}
     </Draggable>

--- a/src/components/Editor/ptext.js
+++ b/src/components/Editor/ptext.js
@@ -67,7 +67,7 @@ export default function Ptext(props) {
           isDragging={snapshot.isDragging}
         >
           <div>
-            <AHCard />
+            <AHCard ptextId={props.ptext?.id} />
           </div>
           <Handle isDragDisabled={isDragDisabled} {...provided.dragHandleProps}>
             <DragHandle />

--- a/src/components/Editor/ptext.js
+++ b/src/components/Editor/ptext.js
@@ -1,0 +1,89 @@
+import React from "react";
+import styled from "styled-components";
+import { Draggable } from "react-beautiful-dnd";
+
+import DragHandle from "@material-ui/icons/DragHandle";
+
+import AHCard from "../Board/Card";
+
+import { setLayoutState } from "../../store/editor/actions";
+import { useDispatch, useSelector } from "react-redux";
+import { selectLayoutState } from "../../store/editor/selectors";
+
+const Container = styled.div`
+  /* border: 1px solid lightgrey; */
+  border-radius: 5px;
+  padding: 8px;
+  margin-bottom: 10px;
+  // background-color: ${(props) => (props.isDragging ? "white" : "white")};
+
+  display: flex;
+`;
+
+const Handle = styled.div`
+  width: 25px;
+  height: 20px;
+  /* background-color: ${(props) =>
+    props.isDragDisabled ? "grey" : "orange"}; */
+  //  background-color: white;
+  color: white; 
+  position: relative;
+  left: -30px;
+`;
+
+export default function Ptext(props) {
+  const dispatch = useDispatch();
+  const layoutState = useSelector(selectLayoutState);
+
+  // OPTIONAL ::: set draggable to disabled
+  const isDragDisabled = false;
+  // const isDragDisabled = props.task.id === "task-1";
+
+  const onTextChangeHandler = (e) => {
+    const newState = {
+      ...layoutState,
+      ptexts: {
+        ...layoutState.ptexts,
+        [props.ptext?.id]: {
+          ...layoutState.ptexts[props.ptext?.id],
+          content: e.target.value,
+        },
+      },
+    };
+    dispatch(setLayoutState(newState));
+  };
+
+  return (
+    <Draggable
+      isDragDisabled={isDragDisabled}
+      draggableId={props.ptext?.id}
+      index={props.index}
+    >
+      {(provided, snapshot) => (
+        <Container
+          isDragDisabled={isDragDisabled}
+          {...provided.draggableProps}
+          ref={provided.innerRef}
+          isDragging={snapshot.isDragging}
+        >
+          <div>
+            <AHCard />
+          </div>
+          <Handle isDragDisabled={isDragDisabled} {...provided.dragHandleProps}>
+            <DragHandle />
+          </Handle>
+          {/* {props.ptext?.content} */}
+          {/* <TextField
+            id="standard-multiline-flexible"
+            label=""
+            multiline
+            fullWidth={true}
+            // rowsMax={4}
+            // value={layoutState.ptexts[props.ptext?.id].content}
+            onChange={onTextChangeHandler}
+          /> */}
+        </Container>
+      )}
+    </Draggable>
+  );
+}

--- a/src/components/Editor/ptextModal.js
+++ b/src/components/Editor/ptextModal.js
@@ -1,0 +1,121 @@
+import React from "react";
+import styled from "styled-components";
+import { Draggable } from "react-beautiful-dnd";
+
+import DragHandle from "@material-ui/icons/DragHandle";
+import CreateIcon from "@material-ui/icons/Create";
+
+import AHCard from "../Board/Card";
+
+// ##################  modal config
+import { makeStyles } from "@material-ui/core/styles";
+import Modal from "@material-ui/core/Modal";
+import Backdrop from "@material-ui/core/Backdrop";
+import Fade from "@material-ui/core/Fade";
+
+const useStyles = makeStyles((theme) => ({
+  modal: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+}));
+
+function CardModal(props) {
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <CreateIcon onClick={handleOpen} fontSize="small" />
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        className={classes.modal}
+        open={open}
+        onClose={handleClose}
+        closeAfterTransition
+        BackdropComponent={Backdrop}
+        BackdropProps={{
+          timeout: 500,
+        }}
+      >
+        <Fade in={open}>
+          <div>
+            <AHCard ptextId={props.ptext?.id} />
+          </div>
+        </Fade>
+      </Modal>
+    </div>
+  );
+}
+// ##################
+
+const Container = styled.div`
+  /* border: 1px solid lightgrey; */
+  border-radius: 5px;
+  padding: 8px;
+  margin-bottom: 10px;
+  // background-color: ${(props) => (props.isDragging ? "white" : "white")};
+
+  display: flex;
+`;
+
+const Handle = styled.div`
+  width: 25px;
+  height: 20px;
+  /* background-color: ${(props) =>
+    props.isDragDisabled ? "grey" : "orange"}; */
+  //  background-color: white;
+  color: white; 
+  position: relative;
+  left: -30px;
+`;
+
+const PencilIcon = styled.div`
+  width: 0;
+  color: white;
+  position: relative;
+  left: -60px;
+  top: 2px;
+`;
+
+export default function Ptext(props) {
+  // OPTIONAL ::: set draggable to disabled
+  const isDragDisabled = false;
+  // const isDragDisabled = props.task.id === "task-1";
+
+  return (
+    <Draggable
+      isDragDisabled={isDragDisabled}
+      draggableId={props.ptext?.id}
+      index={props.index}
+    >
+      {(provided, snapshot) => (
+        <Container
+          isDragDisabled={isDragDisabled}
+          {...provided.draggableProps}
+          ref={provided.innerRef}
+          isDragging={snapshot.isDragging}
+        >
+          <AHCard ptextId={props.ptext?.id} />
+          <PencilIcon>
+            <CardModal props={props} />
+          </PencilIcon>
+
+          <Handle isDragDisabled={isDragDisabled} {...provided.dragHandleProps}>
+            <DragHandle />
+          </Handle>
+        </Container>
+      )}
+    </Draggable>
+  );
+}

--- a/src/store/editor/actions.js
+++ b/src/store/editor/actions.js
@@ -1,0 +1,35 @@
+export const setLayoutState = (newState) => ({
+  type: "SET_LAYOUT_STATE",
+  payload: newState,
+});
+
+export const setContentDescription = (description) => ({
+  type: "SET_CONTENT_DESCRIPTION",
+  payload: description,
+});
+
+export const addNewColumn = () => {
+  return (dispatch, getState) => {
+    const layoutState = getState().editorSliceReducer.layoutState;
+
+    const columns = layoutState.columns;
+    const nrOfColumns = Object.keys(columns).length;
+
+    const newColumnOrder = layoutState.columnOrder;
+    newColumnOrder.push(`column-${nrOfColumns + 1}`);
+
+    const newState = {
+      ...layoutState,
+      columns: {
+        ...columns,
+        [`column-${nrOfColumns + 1}`]: {
+          id: `column-${nrOfColumns + 1}`,
+          title: "Title",
+          ptextIds: [],
+        },
+      },
+      columnOrder: newColumnOrder,
+    };
+    dispatch(setLayoutState(newState));
+  };
+};

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -1,12 +1,12 @@
 const initialState = {
   layoutState: {
     ptexts: {
-      "ptext-1": { id: "ptext-1", content: "content..." },
-      "ptext-2": { id: "ptext-2", content: "content..." },
-      "ptext-3": { id: "ptext-3", content: "content..." },
-      "ptext-4": { id: "ptext-4", content: "content..." },
-      "ptext-5": { id: "ptext-5", content: "content..." },
-      "ptext-6": { id: "ptext-6", content: "content..." },
+      "ptext-1": { id: "ptext-1", content: "content1..." },
+      "ptext-2": { id: "ptext-2", content: "content2..." },
+      "ptext-3": { id: "ptext-3", content: "content3..." },
+      "ptext-4": { id: "ptext-4", content: "content4..." },
+      "ptext-5": { id: "ptext-5", content: "content5..." },
+      "ptext-6": { id: "ptext-6", content: "content6..." },
     },
     columns: {
       "column-1": {

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -1,0 +1,30 @@
+const initialState = {
+  layoutState: {
+    ptexts: {
+      "ptext-1": { id: "ptext-1", content: "content..." },
+    },
+    columns: {
+      "column-1": {
+        id: "column-1",
+        title: "Title",
+        ptextIds: ["ptext-1"],
+      },
+    },
+    //for reordering columns later on
+    columnOrder: ["column-1"],
+  },
+};
+export default function editorSliceReducer(
+  state = initialState,
+  { type, payload }
+) {
+  switch (type) {
+    case "SET_LAYOUT_STATE":
+      return { ...state, layoutState: payload };
+    case "SET_CONTENT_DESCRIPTION":
+      return { ...state, contentDescription: payload };
+
+    default:
+      return state;
+  }
+}

--- a/src/store/editor/reducer.js
+++ b/src/store/editor/reducer.js
@@ -2,16 +2,30 @@ const initialState = {
   layoutState: {
     ptexts: {
       "ptext-1": { id: "ptext-1", content: "content..." },
+      "ptext-2": { id: "ptext-2", content: "content..." },
+      "ptext-3": { id: "ptext-3", content: "content..." },
+      "ptext-4": { id: "ptext-4", content: "content..." },
+      "ptext-5": { id: "ptext-5", content: "content..." },
+      "ptext-6": { id: "ptext-6", content: "content..." },
     },
     columns: {
       "column-1": {
         id: "column-1",
-        title: "Title",
-        ptextIds: ["ptext-1"],
+        title: "...",
+        ptextIds: ["ptext-1", "ptext-2"],
+      },
+      "column-2": {
+        id: "column-2",
+        title: "...",
+        ptextIds: ["ptext-3", "ptext-4"],
+      },
+      "column-3": {
+        id: "column-3",
+        title: "...",
+        ptextIds: ["ptext-5", "ptext-6"],
       },
     },
-    //for reordering columns later on
-    columnOrder: ["column-1"],
+    columnOrder: ["column-1", "column-2", "column-3"],
   },
 };
 export default function editorSliceReducer(

--- a/src/store/editor/selectors.js
+++ b/src/store/editor/selectors.js
@@ -1,0 +1,7 @@
+export const selectLayoutState = (state) => {
+  return state.editorSliceReducer.layoutState;
+};
+
+export const selectContentDescription = (state) => {
+  return state.editorSliceReducer.contentDescription;
+};

--- a/src/store/lookup/actions.js
+++ b/src/store/lookup/actions.js
@@ -1,0 +1,42 @@
+import api from "../../api";
+import { setLayoutState } from "../editor/actions.js";
+
+export function nlpRequest(textBox) {
+  return async function (dispatch) {
+    try {
+      const res = await api("nlp", { method: "POST", data: { textBox } });
+      if (res) {
+        dispatch({ type: "NLP_RESPONSE", payload: res.data });
+        return res.data;
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  };
+}
+
+export function populatePtexts() {
+  return (dispatch, getState) => {
+    const layoutState = getState().editorSliceReducer.layoutState;
+    const columns = layoutState.columns;
+    const sentences = getState().lookupSliceReducer.sentences;
+    let newPtexts = {};
+    let newPtextIds = [];
+
+    sentences.forEach((sentence, index) => {
+      newPtextIds.push(`ptext-${index}`);
+      newPtexts[`ptext-${index}`] = { id: `ptext-${index}`, content: sentence };
+    });
+
+    const newState = {
+      ...layoutState,
+      columns: {
+        ...columns,
+        "column-1": { id: "column-1", title: "part 1", ptextIds: newPtextIds },
+      },
+      ptexts: newPtexts,
+    };
+
+    dispatch(setLayoutState(newState));
+  };
+}

--- a/src/store/lookup/reducer.js
+++ b/src/store/lookup/reducer.js
@@ -1,0 +1,14 @@
+const initialState = {};
+
+export default function lookupSliceReducer(
+  state = initialState,
+  { type, payload }
+) {
+  switch (type) {
+    case "NLP_RESPONSE":
+      return { ...state, sentences: payload };
+
+    default:
+      return state;
+  }
+}

--- a/src/store/lookup/selectors.js
+++ b/src/store/lookup/selectors.js
@@ -1,0 +1,3 @@
+export const selectSentences = (state) => {
+  return state.lookupSliceReducer.sentences;
+};

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -1,8 +1,12 @@
 import { combineReducers } from "redux";
 // import appState from "./appState/reducer";
 // import user from "./user/reducer";
+import lookupSliceReducer from "./lookup/reducer";
+import editorSliceReducer from "./editor/reducer";
 
 export default combineReducers({
   //   appState,
   //   user,
+  lookupSliceReducer,
+  editorSliceReducer,
 });

--- a/src/theme/Header.js
+++ b/src/theme/Header.js
@@ -6,7 +6,6 @@ import AppBar from "@material-ui/core/AppBar";
 import Avatar from "@material-ui/core/Avatar";
 // import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
-import HelpIcon from "@material-ui/icons/Help";
 import Hidden from "@material-ui/core/Hidden";
 import IconButton from "@material-ui/core/IconButton";
 import MenuIcon from "@material-ui/icons/Menu";
@@ -26,7 +25,7 @@ const styles = (theme) => ({
     zIndex: 0,
   },
   menuButton: {
-    marginLeft: -theme.spacing.unit,
+    marginLeft: -theme.spacing(1),
   },
   iconButtonAvatar: {
     padding: 4,
@@ -107,7 +106,7 @@ function Header(props) {
 
 Header.propTypes = {
   classes: PropTypes.object.isRequired,
-  onDrawerToggle: PropTypes.func.isRequired,
+  // onDrawerToggle: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(Header);

--- a/src/theme/Header.js
+++ b/src/theme/Header.js
@@ -47,7 +47,11 @@ function Header(props) {
 
   return (
     <React.Fragment>
-      <AppBar color="primary" position="sticky" elevation={0}>
+      <AppBar
+        style={{ backgroundColor: "#00A0E2" }}
+        position="sticky"
+        elevation={0}
+      >
         <Toolbar>
           <Grid container spacing={8} alignItems="center">
             <Hidden smUp>
@@ -89,7 +93,7 @@ function Header(props) {
       <AppBar
         component="div"
         className={classes.secondaryBar}
-        color="primary"
+        style={{ backgroundColor: "#00A0E2" }}
         position="static"
         elevation={0}
       >

--- a/src/theme/Navigator.js
+++ b/src/theme/Navigator.js
@@ -20,7 +20,7 @@ import Folder from "@material-ui/icons/Folder";
 import SettingsIcon from "@material-ui/icons/Settings";
 import TextFieldsIcon from "@material-ui/icons/TextFields";
 
-import styled from "styled-components";
+// import styled from "styled-components";
 
 const categories = [
   {
@@ -90,7 +90,7 @@ const styles = (theme) => ({
   },
   textDense: {},
   divider: {
-    marginTop: theme.spacing.unit * 2,
+    marginTop: theme.spacing(2),
   },
 });
 

--- a/src/theme/Paperbase.js
+++ b/src/theme/Paperbase.js
@@ -11,6 +11,7 @@ import CssBaseline from "@material-ui/core/CssBaseline";
 import Header from "./Header";
 
 import AHCard from "../components/Board/Card";
+import DndLayout from "../components/Editor/dndLayout";
 
 let theme = createMuiTheme({
   typography: {
@@ -158,6 +159,7 @@ function Paperbase(props) {
           <main className={classes.mainContent}>
             {/* React Router routes go here } */}
             <Route path="/card" component={AHCard} />
+            <Route path="/layout" component={DndLayout} />
           </main>
         </div>
       </div>

--- a/src/theme/Paperbase.js
+++ b/src/theme/Paperbase.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { Route } from "react-router-dom";
 import {
@@ -6,7 +6,6 @@ import {
   createMuiTheme,
   withStyles,
 } from "@material-ui/core/styles";
-import CssBaseline from "@material-ui/core/CssBaseline";
 
 import Header from "./Header";
 
@@ -56,7 +55,7 @@ theme = {
     },
     MuiTabs: {
       root: {
-        marginLeft: theme.spacing.unit,
+        marginLeft: theme.spacing(1),
       },
       indicator: {
         height: 3,
@@ -74,16 +73,10 @@ theme = {
           minWidth: 0,
         },
       },
-      labelContainer: {
-        padding: 0,
-        [theme.breakpoints.up("md")]: {
-          padding: 0,
-        },
-      },
     },
     MuiIconButton: {
       root: {
-        padding: theme.spacing.unit,
+        padding: theme.spacing(1),
       },
     },
     MuiTooltip: {

--- a/src/theme/Paperbase.js
+++ b/src/theme/Paperbase.js
@@ -149,7 +149,14 @@ function Paperbase(props) {
       <div className={classes.root}>
         <div className={classes.appContent}>
           <Header />
-          <main className={classes.mainContent}>
+          <main
+            className={classes.mainContent}
+            style={{
+              // background: "linear-gradient(to bottom right, #E8E8E8, white)",
+              background: "#00A0E2",
+              overflowX: "hidden",
+            }}
+          >
             {/* React Router routes go here } */}
             <Route path="/card" component={AHCard} />
             <Route path="/layout" component={DndLayout} />

--- a/src/theme/SourceEditor.js
+++ b/src/theme/SourceEditor.js
@@ -29,7 +29,7 @@ const styles = (theme) => ({
     display: "block",
   },
   addUser: {
-    marginRight: theme.spacing.unit,
+    marginRight: theme.spacing(1),
   },
   contentWrapper: {
     margin: "40px 16px",


### PR DESCRIPTION
**What this pullrequest does:**

This pullrequest contains the drag and drop functionality for the frontpage 
bulletin-board card layout. It also implements the basic layout and functionality of the 'card edit-mode modal'.
 
**Details:**

* installed react-beautiful-dnd
* created vertically ordered droppables of 'card' draggable
* created a more consistent color scheme for the layout
* implemented a modal of  'card' which opens by clicking the pencil icon on 'card' 
* implemented redux for state recall of card input fields 
* created css gradients based "glue strip bar" under the cards on the layout
